### PR TITLE
Remove BindingPrecedence and declare <~ with DefaultPrecedence

### DIFF
--- a/Sources/Bindings/BindingSubscriber.swift
+++ b/Sources/Bindings/BindingSubscriber.swift
@@ -1,11 +1,6 @@
 import Combine
 
-precedencegroup BindingPrecedence {
-  higherThan: AssignmentPrecedence
-  assignment: true
-}
-
-infix operator <~: BindingPrecedence
+infix operator <~: DefaultPrecedence
 
 public protocol BindingSubscriber: Subscriber, Cancellable {
   @discardableResult


### PR DESCRIPTION
The standard library includes this curious operator declaration:

```swift
infix operator ~> : DefaultPrecedence
```

However there are no protocols are free functions that provide any
definition or hint at its intended semantics.

In light of this, it makes a lot of sense for both operators to exist in
the same precedence group. `DefaultPrecedence` is at a slightly higher
precedence than `BindingPrecedence` was, now binding more tightly than
the ternary operator. This feels reasonable, as now it's possible to,
e.g., switch between two different binding statements in a ternary
expression.
