### PR TITLE
Use Set as the default Subscriptions collection

### DIFF
--- a/Sources/Bindings/BindingOwner.swift
+++ b/Sources/Bindings/BindingOwner.swift
@@ -4,7 +4,7 @@ import Foundation
 private var bindingOwnerSubscriptionsKey: UInt8 = 0
 
 public protocol BindingOwner: AnyObject, ReactiveExtensionProvider {
-  associatedtype Subscriptions: Collection & ExpressibleByArrayLiteral = [AnyCancellable]
+  associatedtype Subscriptions: Collection & ExpressibleByArrayLiteral = Set<AnyCancellable>
     where Subscriptions.Element == AnyCancellable
 
   var subscriptions: Subscriptions { get set }


### PR DESCRIPTION
`Cancellable.store(in:)` is overloaded for two kinds of collection: either any `RangeReplaceableCollection`, or `Set`. Given that `Set` is more specific, prefer it over `Array`.