### PR TITLE
Use _read/set/_modify for associated-object-based subscriptions

### DIFF
--- a/Sources/Bindings/Box.swift
+++ b/Sources/Bindings/Box.swift
@@ -1,4 +1,5 @@
-class Box<T> {
+@usableFromInline
+final class Box<T> {
   var value: T
 
   init(_ value: T) {


### PR DESCRIPTION
Extracts a `_getBox()` helper method that initialises an empty `Subscriptions` box if necessary and then returns a reference. This is used to streamline the implementation of _read/set/_modify accessors. These are also marked inlinable.